### PR TITLE
Add badges functionality

### DIFF
--- a/src/componentR/Rockets.js
+++ b/src/componentR/Rockets.js
@@ -28,10 +28,10 @@ const Rockets = () => {
               {post.name}
             </h1>
             <p>
-              {post.reserved}
+              {post.reserved ? <span className="badge bg-success">Reserved</span> : null}
               {post.desc}
             </p>
-            <button type="button" onClick={reserved} id={post.id} className="btn btn-primary">Reserve Rocket</button>
+            {post.reserved ? <button type="button" onClick={reserved} id={post.id} className="btn btn-secondary">Cancel Reservation</button> : <button type="button" onClick={reserved} id={post.id} className="btn btn-primary">Reserve Rocket</button>}
           </Info>
         </Section>
       ))}

--- a/src/componentR/Rockets.js
+++ b/src/componentR/Rockets.js
@@ -28,7 +28,7 @@ const Rockets = () => {
               {post.name}
             </h1>
             <p>
-              {post.reserved ? <span className="badge bg-success">Reserved</span> : null}
+              {post.reserved ? <span style={{ margin: '5px' }} className="badge bg-success">Reserved</span> : null}
               {post.desc}
             </p>
             {post.reserved ? <button type="button" onClick={reserved} id={post.id} className="btn btn-secondary">Cancel Reservation</button> : <button type="button" onClick={reserved} id={post.id} className="btn btn-primary">Reserve Rocket</button>}

--- a/src/componentR/styles.js
+++ b/src/componentR/styles.js
@@ -13,6 +13,8 @@ export const Section = styled.div`
 export const Picture = styled.img`
     width: 250px;
     margin: 2rem;
+    border-radius: 20px;
+    box-shadow: rgba(0, 0, 0, 0.37) 0 0 5px 2px;
 `;
 
 export const Info = styled.div`

--- a/src/redux/API.js
+++ b/src/redux/API.js
@@ -26,7 +26,7 @@ export const rocketReseve = (currentState, id) => (dispatch) => {
     if (rocket.id != id) {
       return rocket;
     }
-    return { ...rocket, reserved: true };
+    return { ...rocket, reserved: !rocket.reserved };
   });
   dispatch({
     type: RESERVE_ROCKET,


### PR DESCRIPTION
- [x] Rockets that have already been reserved show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket"

![image](https://user-images.githubusercontent.com/74747182/136243583-e85e9826-f0ad-4671-a5b0-16f087f8c57c.png)
